### PR TITLE
fix: Fix capybara version error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :development, :test do
   # BDD for Ruby
   gem 'rspec-rails', '~> 3.6'
   # Capybara is an integration testing tool for rack based web applications. It simulates how a user would interact with a website
-  gem 'capybara', '~> 2.15', '>= 2.15.1'
+  gem 'capybara', '~> 2.15', '>= 2.15.3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.1.0)
-    capybara (2.15.2)
+    capybara (2.15.3)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
@@ -216,7 +216,7 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on (~> 5.0)
   byebug
-  capybara (~> 2.15, >= 2.15.1)
+  capybara (~> 2.15, >= 2.15.3)
   coffee-rails (~> 4.2)
   devise (~> 4.3)
   jbuilder (~> 2.5)


### PR DESCRIPTION
Update capybara version(2.15 >= 2.15.3) due to an error found after 'docker-compose up'.