### PR TITLE
fix: removes "#" symbol before saving hashtags

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -35,7 +35,7 @@ class Tweet < ApplicationRecord
   end
 
   def save_with_hashtag
-    self.hashtag_list = self.description.scan(/#\w+/)
+    self.hashtag_list = self.description.scan(/#\w+/).map { |item| item.gsub('#', '') } 
 
     self.save
   end


### PR DESCRIPTION
removes "#" symbol before saving hashtags